### PR TITLE
Add possible optional proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ You probably wouldn't want to change these
 * ```docker_opts```: Parameters for Docker daemon
 * ```docker_tmpdir```: Path to tmp directory to be used by Docker
 * ```docker_config_file```: Path to Docker config file (default is /etc/default/docker)
+* ```docker_proxy```: Hostname of an HTTP proxy (default is undefined)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,6 +73,32 @@
     state: present
   when: docker_user != ""
 
+- name: Create dir for proxy config
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: docker_proxy is defined
+
+- name: Configure HTTP proxy
+  template:
+    src: http-proxy.conf.j2
+    dest: /etc/systemd/system/docker.service.d/http-proxy.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: docker_proxy is defined
+  register: proxy
+
+- name: Reload systemctl
+  command: systemctl daemon-reload
+  become: yes
+  when: proxy.changed
+  notify:
+    - Restart docker
+
 - name: Start docker
   become: yes
   service:

--- a/templates/http-proxy.conf.j2
+++ b/templates/http-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment="HTTP_PROXY=http://{{ docker_proxy }}/"


### PR DESCRIPTION
docker_proxy is the hostname of an HTTP proxy. If it is defined, docker will be configured to use it. Otherwise nothing changes compared to the old behavior. 